### PR TITLE
Advance F3H Implementation

### DIFF
--- a/inc/statically_pagebooster.class.php
+++ b/inc/statically_pagebooster.class.php
@@ -6,25 +6,120 @@ class Statically_PageBooster
         $options = Statically::get_options();
 
         if ( 1 !== $options['pagebooster_custom_js_enabled'] ) {
-            if ( $options['pagebooster_content'] ) {
+            if ( !empty( $options['pagebooster_content'] ) ) {
                 $content = $options['pagebooster_content'];
             } else {
                 $content = '#page';
             }
 
-            $inline = 'let f3h = new F3H(state = {
-                cache: true,
-            }),
-                content = document.querySelector("' . $content . '");
-            f3h.on(200, function(response) {
-                document.title = response.title;
-                content.innerHTML = response.querySelector("' . $content . '").innerHTML;
-            });';
+            $inline = <<<JS
+F3H.state.statically = '$content';
+
+// TODO: Store this to an external file and leave the
+// state above inline so that we can minify the code below!
+(function(win, doc) {
+
+function $$(selector, root) {
+    return (root || doc).querySelector(selector);
+}
+
+function $$$(selector, root) {
+    return (root || doc).querySelectorAll(selector);
+}
+
+let f3h = new F3H({
+        turbo: true, // Enable cache and URL pre-fetching on hover
+        sources: 'a[href]:not([href*="/wp-admin/"]), form:not([action*="/wp-admin/"])', // Ignore links to the admin area
+    }),
+    currentBody = doc.body,
+    currentElements = $$$(F3H.state.statically),
+    currentMetaDescription = $$('meta[content][name="description"]'),
+    currentMetaDescriptionOG = $$('meta[content][name="og:description"]'),
+    currentRoot = doc.documentElement;
+
+f3h.on(200, function(next) {
+    let nextBody = next.body,
+        nextElements = $$$(F3H.state.statically, next),
+        nextMetaDescription = $$('meta[content][name="description"]', next),
+        nextMetaDescriptionOG = $$('meta[content][name="og:description"]', next),
+        nextRoot = next.documentElement;
+    // Update document title
+    doc.title = next.title;
+    // Update meta description data if any
+    currentMetaDescription &&
+    nextMetaDescription &&
+    (currentMetaDescription.content = nextMetaDescription.content);
+    // Update open-graph meta description data if any
+    currentMetaDescriptionOG &&
+    nextMetaDescriptionOG &&
+    (currentMetaDescriptionOG.content = nextMetaDescriptionOG.content);
+    // Update body class names
+    currentBody &&
+    nextBody &&
+    (currentBody.className = nextBody.className);
+    // Update root class names (if any)
+    currentRoot &&
+    nextRoot &&
+    (currentRoot.className = nextRoot.className);
+
+    currentElements.forEach(function(element, index) {
+        if (nextElements[index]) {
+            element.className = nextElements[index].className;
+            element.innerHTML = nextElements[index].innerHTML;
+        }
+    });
+
+    doAutoDetectScriptsToRefresh(this);
+});
+
+function doAutoDetectScriptsToRefresh(base) {
+    let id,
+        script,
+        scripts = base.scripts,
+        scriptContent,
+        scriptSource;
+    for (id in scripts) {
+        script = scripts[id];
+        scriptContent = script[1] || "";
+        scriptSource = script[2].src || "";
+        // Ignore case-sensitivity and white-spaces
+        scriptContent = scriptContent.toLowerCase().replace(/\s+/g, "");
+        // Ignore case-sensitivity, URL protocol, query string and hash
+        scriptSource = scriptSource.toLowerCase().replace(/^https?:\/\/|[?&#].*$/g, "");
+        // Remove by content
+        if (scriptContent) {
+            if (
+                // Maybe Google Analytic script
+                /\b(_gaq|datalayer|gtag)\b/.test(scriptContent) ||
+                // Maybe Google AdSense script
+                /\badsbygoogle\b/.test(scriptContent)
+            ) {
+                delete scripts[id];
+            }
+        }
+        // Remove by source path
+        if (scriptSource) {
+            if (
+                // Maybe Twitter Embed script
+                'platform.twitter.com/widgets.js' === scriptSource
+                // ...
+            ) {
+                delete scripts[id];
+            }
+        }
+    }
+}
+
+// Expose `f3h` variable to global to be used by other plugins
+win.f3h = f3h;
+
+})(this, this.document);
+JS;
         } else {
             $inline = $options['pagebooster_custom_js'];
         }
 
-        wp_enqueue_script( 'statically-f3h', Statically::CDN . 'gh/taufik-nurrohman/f3h/543cce1/f3h.min.js', array(), STATICALLY_VERSION );
+        wp_enqueue_script( 'statically-f3h', Statically::CDN . 'gh/taufik-nurrohman/f3h/a3196bf7/f3h.min.js', array(), STATICALLY_VERSION );
         wp_add_inline_script( 'statically-f3h', $inline );
     }
 }

--- a/views/options-general.php
+++ b/views/options-general.php
@@ -31,7 +31,7 @@
                     </label>
 
                     <p class="description">
-                        <?php _e( 'Statically API key to make this plugin working &#8212; <a href="https://statically.io/wordpress/" target="_blank">Get one here</a>', 'statically' ); ?>
+                        <?php _e( 'Statically API key to make this plugin working. Never share it to anybody! Treat this API key as a password. &#8212; <a href="https://statically.io/wordpress/" target="_blank">Get one here</a>', 'statically' ); ?>
                     </p>
                 </fieldset>
             </td>

--- a/views/options-labs.php
+++ b/views/options-labs.php
@@ -23,7 +23,7 @@
                     <label for="statically_pagebooster-content">
                         <h4><?php _e( 'Selector', 'statically' ); ?></h4>
                         <input type="text" name="statically[pagebooster_content]" id="statically_pagebooster-content" value="<?php echo $options['pagebooster_content']; ?>" style="max-width: 10em" />
-                        <?php _e( ' &#8212; Can be class, ID, or element.', 'statically' ); ?>
+                        <?php _e( ' &#8212; Can be class, ID, or element selector.', 'statically' ); ?>
                     </label>
                 </fieldset>
 


### PR DESCRIPTION
 - Enable auto-refresh for external scripts. Can be configured by users.
 - Page booster content selector is now accepts multiple elements too.
 - Exclude links to WordPress admin area.