### PR TITLE
Replace `no-js` Class to `js` Class if Any

### DIFF
--- a/static/pagebooster.js
+++ b/static/pagebooster.js
@@ -41,7 +41,7 @@ f3h.on(200, function(next) {
     // Update root class names (if any)
     currentRoot &&
     nextRoot &&
-    (currentRoot.className = nextRoot.className);
+    (currentRoot.className = nextRoot.className.replace(/\bno-js\b/, 'js'));
 
     currentElements.forEach(function(element, index) {
         if (nextElements[index]) {


### PR DESCRIPTION
This fixes the &ldquo;always expanded sub-menus&rdquo; bug in _twentyfifteen_ theme.